### PR TITLE
Remove trailing tab on table output.

### DIFF
--- a/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
@@ -351,21 +351,29 @@ object SolrQuerySupport {
 
     val stringBuilder = new StringBuilder
 
+
     while (streamingIterator.hasNext) {
       val doc = mapAsScalaMap(streamingIterator.next())
       // Get field names from first doc and add them as headers
       if (streamingIterator.getNumDocs == 1) {
         doc.keySet.foreach(s => stringBuilder.++=(s"${s}\t"))
+        if (stringBuilder.length > 0) {
+          stringBuilder.deleteCharAt(stringBuilder.length - 1); // This efficiently removes the trailing tab.
+        }
         stringBuilder.++=(s"\n")
       }
+
       doc.foreach(f => {
         f._2 match {
           case ul: java.util.Collection[_] => stringBuilder.++=(s"${StringUtils.join(ul, ",")}\t")
-          case m: java.util.Map[_, _] => logger.info("Map ignored")// ignore maps for now
+          case m: java.util.Map[_, _] => logger.info("Map ignored") // ignore maps for now
           case a: AnyRef => stringBuilder.++=(s"${String.valueOf(a)}\t")
           case _ => stringBuilder.++=("")
         }
       })
+      if (stringBuilder.length > 0 && stringBuilder.charAt(stringBuilder.length - 1) == '\t') {
+        stringBuilder.deleteCharAt(stringBuilder.length - 1); // This efficiently removes the trailing tab.
+      }
       stringBuilder.++=(s"\n")
     }
     if (logger.isDebugEnabled()) {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -143,7 +143,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     val header = tableData(0)
     val headerFields = header.split("\t")
     assert(headerFields.size == 2)
-    assert(header.equals("field1_s\tfield3_i\t"))
+    assert(header.equals("field1_s\tfield3_i"))
     tableData.foreach(td => {
       val contents = td.split("\t")
       assert(contents.size == 2)


### PR DESCRIPTION
Currently the Zeppelin default table view doesn't display for Streaming Expressions because of a trailing tab character on the table output. This small change removes the trailing tab from each line in the table. 

A small adjustment to the tests was needed after this fix and the table view works fine after I copied the jar into my Zeppelin install and manually tested.