### PR TITLE
Use HttpSolrClient to talk to Solr instead of CloudSolrClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,19 @@
 2. Install this interpreter via command
 
 ```apple js
-./bin/install-interpreter.sh --name solr --artifact com.lucidworks.zeppelin:zeppelin-solr:0.1.3
+./bin/install-interpreter.sh --name solr --artifact com.lucidworks.zeppelin:zeppelin-solr:0.1.4
 ```
 
 After running the above command
 
 1. Restart Zeppelin
-2. Create interpreter setting in 'Interpreter' menu on Zeppelin GUI
-3. Configure the existing 'solr' interpreter to point to zkhost of SolrCloud
+2. On the Interpreters page configure the 'solr' interpreter to point to a Solr base Url.
+3. Create a notebook with the default interpreter set to Solr.
 
-![create-settings](https://raw.githubusercontent.com/lucidworks/zeppelin-solr/master/images/create-interp-setting.png)
-
-### Configuring the Interpreter
-Set the config `solr.zkhost ` in the Solr Interpreter settings. This should point to the zkhost of SolrCloud cluster
-
-### Commands list
-List the collections in the SolrCloud
-
-Usage: `list`
+Commands:
 
 #### use
-Set a collection to use in the notebook. Displays the defined fields that have data with their type
+Set a collection to use in the notebook.
 
 Usage: `use {collection_name}`
 
@@ -42,14 +34,14 @@ Issue a query with facet fields and display the facet counts. No need to explici
 Usage: `facet {facet-params}`
 
 #### stream
-Issue a streaming expression query and display the output as a table
+Issue a streaming expression query and display the output as a table (No prefix required)
 
-Usage: `stream {stream-expr}`
+Usage: `{stream-expr}`
 
 #### sql
-Issue an Solr SQL query and display the results as a table
+Issue an Solr SQL query and display the results as a table (No prefix required)
 
-Usage: `sql {sql-string}`
+Usage: `{sql-string}`
 
 ### Troubleshooting 
 

--- a/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
@@ -39,8 +39,6 @@ public class SolrInterpreter extends Interpreter {
     baseURL = getProperty(BASE_URL);
     logger.info("Connecting to Solr host {}", baseURL);
     //Default to collection1
-    collection = "collection1";
-    solrClient = SolrSupport.getNewHttpSolrClient(baseURL+"/"+collection);
   }
 
   @ZeppelinApi
@@ -59,10 +57,12 @@ public class SolrInterpreter extends Interpreter {
     if ("use".equals(args[0])) {
       if (args.length == 2) {
         collection = args[1];
-        try {
-          solrClient.close();
-        } catch (Exception e) {
-          logger.error("Error closing connection", e);
+        if(solrClient != null) {
+          try {
+            solrClient.close();
+          } catch (Exception e) {
+            logger.error("Error closing connection", e);
+          }
         }
         solrClient = SolrSupport.getNewHttpSolrClient(baseURL+"/"+collection);
         lukeResponse = SolrQuerySupport.getFieldsFromLuke(solrClient, collection);
@@ -73,6 +73,11 @@ public class SolrInterpreter extends Interpreter {
         String msg = "Specify the collection to use for this dashboard. Example: use {collection_name}";
         return new InterpreterResult(InterpreterResult.Code.INCOMPLETE, InterpreterResult.Type.TEXT, msg);
       }
+    }
+
+    if(collection == null) {
+      String msg = "Specify the collection to use for this dashboard. Example: use {collection_name}";
+      return new InterpreterResult(InterpreterResult.Code.INCOMPLETE, InterpreterResult.Type.TEXT, msg);
     }
 
     if ("search".equals(args[0])) {

--- a/src/main/java/com/lucidworks/zeppelin/solr/query/StreamingResultsIterator.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/query/StreamingResultsIterator.java
@@ -1,6 +1,7 @@
 package com.lucidworks.zeppelin.solr.query;
 
 import com.lucidworks.zeppelin.solr.SolrQuerySupport;
+import com.lucidworks.zeppelin.solr.SolrSupport;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -57,6 +58,8 @@ public class StreamingResultsIterator extends ResultsIterator<SolrDocument> {
     } else {
       solrId = solrServer.toString();
     }
+
+
 
     this.closeAfterIterating = !(solrServer instanceof CloudSolrClient);
     this.solrQuery = solrQuery;

--- a/src/main/resources/interpreter-setting.json
+++ b/src/main/resources/interpreter-setting.json
@@ -4,11 +4,11 @@
     "name": "solr",
     "className": "com.lucidworks.zeppelin.solr.SolrInterpreter",
     "properties": {
-      "solr.zkhost": {
+      "solr.baseUrl": {
         "envName": null,
-        "propertyName": "solr.zkhost",
-        "defaultValue": "localhost:9983",
-        "description": "The ZooKeeper Host connection string for the SolrCloud cluster."
+        "propertyName": "solr.baseUrl",
+        "defaultValue": "http://localhost:8983/solr",
+        "description": "The base Url of the Solr instance Zeppelin is connecting to"
       }
     },
     "editor": {

--- a/src/main/scala/com/lucidworks/zeppelin/solr/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/zeppelin/solr/SolrSupport.scala
@@ -112,8 +112,18 @@ object SolrSupport {
       .build()
   }
 
+  private def getHttpSolrClient(shardUrl: String): HttpSolrClient = {
+    new HttpSolrClient.Builder()
+      .withBaseSolrUrl(shardUrl)
+      .build()
+  }
+
   def getNewHttpSolrClient(shardUrl: String, zkHost: String): HttpSolrClient = {
     getHttpSolrClient(shardUrl, zkHost)
+  }
+
+  def getNewHttpSolrClient(shardUrl: String): HttpSolrClient = {
+    getHttpSolrClient(shardUrl)
   }
 
   def getCachedHttpSolrClient(shardUrl: String, zkHost: String): HttpSolrClient = {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -6,48 +6,23 @@ import org.apache.zeppelin.interpreter.InterpreterResult
 
 class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
 
-  test("Test list command") {
-    val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
-    val solrInterpreter = new SolrInterpreter(properties)
-    solrInterpreter.open()
 
-    val result = solrInterpreter.interpret("list", null)
-    assert(result.code().eq(InterpreterResult.Code.SUCCESS))
-    assert(result.message().size() == 1)
-    assert(result.message().get(0) != null)
-    assert(result.message().get(0).getType.eq(InterpreterResult.Type.TEXT))
-
-    val cols = result.message().get(0).getData.split("\n").toSet
-    assert(cols == collections.toSet)
-  }
 
   test("Test use command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
     val result = solrInterpreter.interpret(s"use ${collections(0)}", null)
     assert(result.code().eq(InterpreterResult.Code.SUCCESS))
-    assert(result.message().size() == 3)
-
-    val msgs = result.message()
-    val table = msgs.get(0)
-    assert(table.getType.eq(InterpreterResult.Type.TABLE))
-    val tableData = table.getData.split("\n")
-    assert(tableData.size == 8) // 6 fields + _version_ + header
-    assert(tableData(0).equals("Name\tType\tDocs"))
-    tableData.foreach(td => {
-      val contents = td.split("\t")
-      assert(contents.size == 3)
-      assert(contents.forall(f => f != null && f.length > 1))
-    })
   }
+
+
 
   test("Test search command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -74,19 +49,11 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     })
   }
 
-  test("Test search command without collection") {
-    val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
-    val solrInterpreter = new SolrInterpreter(properties)
-    solrInterpreter.open()
 
-    val result = solrInterpreter.interpret(s"search q=*:*", null)
-    assert(result.code().eq(InterpreterResult.Code.INCOMPLETE))
-  }
 
   test("Test facet command with use command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -105,9 +72,10 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     assert(header.equals("field1_s\tCount"))
   }
 
+
   test("Test facet command without use command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -125,9 +93,11 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     assert(header.equals("field1_s\tCount"))
   }
 
+
+
   test("Test stream command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -155,7 +125,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
 
   test("Test stream command 2") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -182,9 +152,10 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
   }
 
 
+
   test("Test SQL command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -211,7 +182,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
 
   test("Test SQL command 2") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -235,4 +206,5 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       } ))
     })
   }
+
 }

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -73,6 +73,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
   }
 
 
+  //Facet command must always have collection sert with use
   test("Test facet command without use command") {
     val properties = new Properties()
     properties.put(SolrInterpreter.BASE_URL, baseUrl)
@@ -80,17 +81,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     solrInterpreter.open()
 
     val result = solrInterpreter.interpret(s"facet q=*:*&facet.field=field1_s&collection=${collections(0)}", null)
-    assert(result.code().eq(InterpreterResult.Code.SUCCESS))
-    assert(result.message().size() == 2)
-    val msgs = result.message()
-    val table = msgs.get(0)
-    assert(table.getType.eq(InterpreterResult.Type.TABLE))
-    val tableData = table.getData.split("\n")
-    assert(tableData.size == 21) // 10 docs + header_
-    val header = tableData(0)
-    val headerFields = header.split("\t")
-    assert(headerFields.size == 2)
-    assert(header.equals("field1_s\tCount"))
+    assert(result.code().eq(InterpreterResult.Code.INCOMPLETE))
   }
 
 

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterSettingsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterSettingsTest.scala
@@ -7,16 +7,7 @@ import org.apache.zeppelin.interpreter.InterpreterResult
 
 
 class SolrInterpreterSettingsTest extends TestSuiteBuilder {
-
-  test("Test interpreter settings") {
-    val properties = new Properties()
-    properties.put(SolrInterpreter.BASE_URL, baseUrl)
-    val solrInterpreter = new SolrInterpreter(properties)
-    solrInterpreter.open()
-    assert(solrInterpreter.getCloudClient != null)
-  }
-
-
+  
 
   test("Unknown command") {
     val properties = new Properties()

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterSettingsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterSettingsTest.scala
@@ -10,24 +10,17 @@ class SolrInterpreterSettingsTest extends TestSuiteBuilder {
 
   test("Test interpreter settings") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
     assert(solrInterpreter.getCloudClient != null)
   }
 
-  test("Test invalid interpreter settings") {
-    val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, "localhost12:12121")
-    val solrInterpreter = new SolrInterpreter(properties)
 
-    val caughtException = intercept[Throwable] { solrInterpreter.open() }
-    assert(caughtException.getCause.isInstanceOf[SolrException])
-  }
 
   test("Unknown command") {
     val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
@@ -35,13 +28,5 @@ class SolrInterpreterSettingsTest extends TestSuiteBuilder {
     assert(result.code().eq(InterpreterResult.Code.INCOMPLETE))
   }
 
-  test("Invalid use command") {
-    val properties = new Properties()
-    properties.put(SolrInterpreter.ZK_HOST, zkHost)
-    val solrInterpreter = new SolrInterpreter(properties)
-    solrInterpreter.open()
-
-    val result = intercept[IllegalArgumentException](solrInterpreter.interpret("use abc", null))
-  }
 
 }

--- a/src/test/scala/com/lucidworks/zeppelin/solr/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/TestFramework.scala
@@ -1,10 +1,8 @@
 package com.lucidworks.zeppelin.solr
 
 import java.io.File
-import java.util.Collections
 
 import org.apache.commons.io.FileUtils
-import org.apache.solr.SolrTestCaseJ4.CloudSolrClientBuilder
 import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.cloud.MiniSolrCloudCluster
 import org.eclipse.jetty.servlet.ServletHolder
@@ -18,6 +16,7 @@ trait SolrCloudTestBuilder extends BeforeAndAfterAll {
   @transient var cluster: MiniSolrCloudCluster = _
   @transient var cloudClient: CloudSolrClient = _
   var zkHost: String = _
+  var baseUrl : String = _
   var testWorkingDir: File = _
 
   override def beforeAll(): Unit = {
@@ -44,6 +43,9 @@ trait SolrCloudTestBuilder extends BeforeAndAfterAll {
       testWorkingDir.toPath, solrXmlContents, extraServlets, null /* extra filters */)
     cloudClient = cluster.getSolrClient
     cloudClient.connect()
+    //val runner = cluster.
+    //var url : URL = runner.getBaseUrl()
+    baseUrl = "http://localhost:"+cluster.getJettySolrRunner(0).getLocalPort+"/solr"
 
     assertTrue(!cloudClient.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
     zkHost = cluster.getZkServer.getZkAddress


### PR DESCRIPTION
This PR changes the internal client to HttpSolrClient instead of CloudSolrClient. There are a number of reasons for this change:

1) CloudSolrClient requires direct access to Zookeeper which may not be a good idea for security reasons because Zookeeper could be managing other applications besides Solr.

2) CloudSolrClient requires a stateful persistent connection with ZooKeeper which can make it brittle if the network connection is not very reliable.

3) Streaming Expressions will eventually have full support in non-SolrCloud mode. 

4) Load balancing is quite easy to accomplish with nginx servers so using CloudSolrClient as a load balancer is not really needed from inside Zeppelin itself.