### PR TITLE
Preserve fl order

### DIFF
--- a/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
@@ -254,7 +254,7 @@ object SolrQuerySupport {
     if (userFields != null) {
       val userFieldsArray = List(userFields.split(","):_*)
       logger.info(s"User requested fields ${userFieldsArray}")
-      fieldsList = fieldsList.filter(p => userFieldsArray.contains(p))
+      fieldsList = userFieldsArray
       if (userFieldsArray.contains("score")) {
         fieldsList =  "score" :: fieldsList
       }

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -49,6 +49,30 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     })
   }
 
+  test("Test search command preserves fl order") {
+    val properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    val solrInterpreter = new SolrInterpreter(properties)
+    solrInterpreter.open()
+
+    solrInterpreter.interpret(s"use ${collections(0)}", null)
+    val result = solrInterpreter.interpret(s"search q=*:*&fl=id,field3_i,field2_s,field5_ii", null)
+    assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+    assert(result.message().size() == 2)
+
+    val msgs = result.message()
+    val table = msgs.get(0)
+    assert(table.getType.eq(InterpreterResult.Type.TABLE))
+    val tableData = table.getData.split("\n")
+    assert(tableData.size == 11) // 10 docs + header_
+    val header = tableData(0)
+    val headerFields = header.split("\t")
+    assert(headerFields.size == 4)
+    assert(header.equals("id\tfield3_i\tfield2_s\tfield5_ii"))
+
+  }
+
+
 
 
   test("Test facet command with use command") {


### PR DESCRIPTION
The `fl` parameter is currently used as a filter, but the order of fields in the `fl` param isn't preserved, which is annoying in the Zeppelin table display.

This fix seems kind of simplistic!