### PR TITLE
Add jdbc connection params when needed

### DIFF
--- a/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
@@ -22,6 +22,7 @@ public class SolrInterpreter extends Interpreter {
 
   private static Logger logger = LoggerFactory.getLogger(SolrInterpreter.class);
   public static final String BASE_URL = "solr.baseUrl";
+  public static final String COLLECTION = "solr.collection";
   public static final String JDBC_URL = "jdbc.url";
   public static final String JDBC_DRIVER = "jdbc.driver";
 
@@ -40,7 +41,14 @@ public class SolrInterpreter extends Interpreter {
   public void open() {
     baseURL = getProperty(BASE_URL);
     logger.info("Connecting to Solr host {}", baseURL);
-    //Default to collection1
+    collection = getProperty(COLLECTION);
+    if(collection != null) {
+      //Set the base collection but don't do the Luke response.
+      //The get the luke response uses must specify use.
+      //Streaming Expressions and SQL don't require a luke response. They just require a collection and client
+      //So "use" is not required for streaming expressions or sql if default collection is set.
+      solrClient = SolrSupport.getNewHttpSolrClient(baseURL+"/"+collection);
+    }
   }
 
   @ZeppelinApi
@@ -83,6 +91,10 @@ public class SolrInterpreter extends Interpreter {
     }
 
     if ("search".equals(args[0])) {
+      if(lukeResponse == null) {
+        returnCollectionNull();
+      }
+
       if (args.length == 2) {
         SolrQuery searchSolrQuery = SolrQuerySupport.toQuery(args[1]);
         try {
@@ -99,6 +111,9 @@ public class SolrInterpreter extends Interpreter {
     }
 
     if ("facet".equals(args[0])) {
+      if(lukeResponse == null) {
+        return returnCollectionNull();
+      }
       if (args.length == 2) {
         SolrQuery searchSolrQuery = SolrQuerySupport.toQuery(args[1]);
         if (collection == null) {

--- a/src/main/resources/interpreter-setting.json
+++ b/src/main/resources/interpreter-setting.json
@@ -9,6 +9,18 @@
         "propertyName": "solr.baseUrl",
         "defaultValue": "http://localhost:8983/solr",
         "description": "The base Url of the Solr instance Zeppelin is connecting to"
+      },
+      "jdbc.url": {
+        "envName": null,
+        "propertyName": "jdbc.url",
+        "defaultValue": "jdbc:hive2://localhost:8768/default;transportMode=http;httpPath=fusion;user=admin;password=password123",
+        "description": "The jdbc connection url (Only used with the jdbc Streaming Expression if the connection is not specified.))"
+      },
+      "jdbc.driver": {
+        "envName": null,
+        "propertyName": "jdbc.driver",
+        "defaultValue": "org.apache.hive.jdbc.HiveDriver",
+        "description": "The jdbc driver (Only used with the jdbc Streaming Expression if the connection is not specified.)"
       }
     },
     "editor": {

--- a/src/main/resources/interpreter-setting.json
+++ b/src/main/resources/interpreter-setting.json
@@ -10,6 +10,12 @@
         "defaultValue": "http://localhost:8983/solr",
         "description": "The base Url of the Solr instance Zeppelin is connecting to"
       },
+      "solr.collection": {
+        "envName": null,
+        "propertyName": "solr.collection",
+        "defaultValue": "collection1",
+        "description": "The default collection to send requests to."
+      },
       "jdbc.url": {
         "envName": null,
         "propertyName": "jdbc.url",

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -114,13 +114,13 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     })
   }
 
-  test("Test stream command 2") {
+  test("Test stream command 3") {
     val properties = new Properties()
     properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    properties.put(SolrInterpreter.COLLECTION, collections(0))
     val solrInterpreter = new SolrInterpreter(properties)
     solrInterpreter.open()
 
-    solrInterpreter.interpret(s"use ${collections(0)}", null)
     val result = solrInterpreter.interpret(s"""search(${collections(0)}, q="*:*", fl="field1_s,field3_i", sort="field1_s asc", qt="/export")""", null)
     assert(result.code().eq(InterpreterResult.Code.SUCCESS))
     assert(result.message().size() == 2)

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -142,6 +142,33 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     })
   }
 
+  test("Test JDBC Param Injection") {
+    var properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    properties.put(SolrInterpreter.JDBC_URL, "jdbc:hive//blah")
+    properties.put(SolrInterpreter.JDBC_DRIVER, "HiveDrive")
+    var solrInterpreter = new SolrInterpreter(properties)
+    //Assert properties are added
+    var expr = solrInterpreter.addJDBCParams("jdbc(sql=\"select a from b\")")
+    assert(expr.equals("jdbc(sort=\"id desc\", connection=\"jdbc:hive//blah\", driver=\"HiveDrive\", sql=\"select a from b\")"))
+
+    //Assert properties are not added
+    expr = solrInterpreter.addJDBCParams("jdbc(connection=\"blah\", sql=\"select a from b\")")
+    assert(expr.equals("jdbc(connection=\"blah\", sql=\"select a from b\")"))
+
+
+    //Assert the sort is not touched
+    expr = solrInterpreter.addJDBCParams("jdbc(sort=\"blah asc\", sql=\"select a from b\")")
+    assert(expr.equals("jdbc(connection=\"jdbc:hive//blah\", driver=\"HiveDrive\", sort=\"blah asc\", sql=\"select a from b\")"))
+
+
+    properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    solrInterpreter = new SolrInterpreter(properties)
+    //Assert properties are not added as there are no properties.
+    expr = solrInterpreter.addJDBCParams("jdbc(sql=\"select a from b\")")
+    assert(expr.equals("jdbc(sql=\"select a from b\")"))
+  }
 
 
   test("Test SQL command") {


### PR DESCRIPTION
The **jdbc Streaming Expression** requires **jdbc connection parameters** to be supplied. There are a number of reasons that this is not desirable from inside Zeppelin paragraphs. One reason is it creates noise in the code and needless repetition. The other issues is that sharing notebook code automatically means sharing jdbc connection parameters. 

This ticket allows for configuration of the **jdbc** connection params as part of the interpreter config. The initial release of this is for convenience and improved usability of the **jdbc Streaming Expression** with the Zeppelin-solr interpreter. Security has not been addressed in this PR and will be addressed in future PR's.

