### PR TITLE
Preserve null fields

### DIFF
--- a/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
@@ -325,7 +325,27 @@ object SolrQuerySupport {
     result
   }
 
-  def doStreamingQuery(
+  def doStreamingIterator(
+                        streamingExpression: String,
+                        solrClient: HttpSolrClient,
+                        collection: String,
+                        queryType: String): StreamingExpressionResultIterator = {
+    val query = new SolrQuery()
+    if (queryType.equals("stream")) {
+      query.set("expr", streamingExpression.substring(queryType.length + 1).replaceAll("\\s+", " "))
+      query.set("qt", "/stream")
+      logger.info(s"Solr query with streaming expression: ${query}")
+    } else if (queryType.equals("sql")) {
+      query.set("sql", streamingExpression.substring(queryType.length + 1).replaceAll("\\s+", " "))
+      query.set("qt", "/sql")
+      logger.info(s"Solr query with SQL statement: ${query}")
+    }
+
+    return new StreamingExpressionResultIterator(solrClient.getBaseURL, collection, query)
+  }
+
+
+    def doStreamingQuery(
       streamingExpression: String,
       solrClient: HttpSolrClient,
       collection: String,


### PR DESCRIPTION
Currently the table header is taken from the first result when processing streaming expressions. Also each subsequent tuple is assumed to have each field the first tuple has. This causes all kinds of display problems when either the first tuple or subsequent tuples don't contain all fields in the result set.

In general this doesn't cause issues with aggregations or statistical visualizations because these result sets have very consistent field structure across the result set. But it reeks havoc with exploratory searches viewed in tables.

This ticket does a very thorough job of creating the header by looping through each tuple to create the unique set of fields. It also ensures that nulls are preserved in all tuples with tabs.