### PR TITLE
update to Zeppelin 0.9.0-preview1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <solr.version>8.4.1</solr.version>
+        <solr.version>8.5.0</solr.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <guava.version>25.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,10 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <solr.version>7.5.0</solr.version>
+        <solr.version>8.4.1</solr.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <guava.version>15.0</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <zeppelin.version>0.9.0-preview1</zeppelin.version>
         <plugin.compiler.version>3.1</plugin.compiler.version>
     </properties>
@@ -282,7 +282,16 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-site-plugin</artifactId>
+              <version>3.7.1</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>3.0.0</version>
+            </plugin>
         </plugins>
 
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <guava.version>15.0</guava.version>
-        <zeppelin.version>0.8.0</zeppelin.version>
+        <zeppelin.version>0.9.0-preview1</zeppelin.version>
         <plugin.compiler.version>3.1</plugin.compiler.version>
     </properties>
 
@@ -155,7 +155,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>4.3.1</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -38,17 +38,17 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     assert(tableData.size == 11) // 10 docs + header_
     val header = tableData(0)
     val headerFields = header.split("\t")
-    assert(headerFields.size == 7)
+    assert(headerFields.size == 8)
 
     tableData.foreach(td => {
       val contents = td.split("\t")
-      assert(contents.size == 7)
+      assert(contents.size == 8)
       assert(contents.forall(f => {
         f != null && f.length > 0
       } ))
     })
   }
-  
+
   // Make sure the collection parameter is passed through to Solr
   test("Test search command specifing non existent collection fails") {
     val properties = new Properties()
@@ -61,7 +61,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     assert(result.code().eq(InterpreterResult.Code.ERROR))
     assert(result.message().size() == 1)
 
-  }  
+  }
 
   test("Test search command preserves fl order") {
     val properties = new Properties()


### PR DESCRIPTION
This updates the Zeppelin dependency, and I had to bump the Scala plugin version to get it to build.