### PR TITLE
Remove client-close logic in StreamingResultsIterator

### DIFF
--- a/src/main/java/com/lucidworks/zeppelin/solr/query/StreamingResultsIterator.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/query/StreamingResultsIterator.java
@@ -35,7 +35,6 @@ public class StreamingResultsIterator extends ResultsIterator<SolrDocument> {
   protected boolean usingCursors = false;
   protected String nextCursorMark = null;
   protected String cursorMarkOfCurrentPage = null;
-  protected boolean closeAfterIterating = false;
   protected LinkedBlockingDeque<SolrDocument> queue;
   protected Integer maxSampleDocs = null;
   protected String solrId = null;
@@ -59,9 +58,6 @@ public class StreamingResultsIterator extends ResultsIterator<SolrDocument> {
       solrId = solrServer.toString();
     }
 
-
-
-    this.closeAfterIterating = !(solrServer instanceof CloudSolrClient);
     this.solrQuery = solrQuery;
     this.usingCursors = (cursorMark != null);
     this.nextCursorMark = cursorMark;
@@ -96,11 +92,6 @@ public class StreamingResultsIterator extends ResultsIterator<SolrDocument> {
       hasNext = (totalDocs > 0 && iterPos < currentPageSize);
     }
 
-    if (!hasNext && closeAfterIterating) {
-      try {
-        solrServer.close();
-      } catch (Exception exc) { exc.printStackTrace(); }
-    }
     return hasNext;
   }
 

--- a/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/zeppelin/solr/SolrQuerySupport.scala
@@ -141,7 +141,7 @@ object SolrQuerySupport {
       }
     } catch {
       case e: Exception =>
-        logger.error("Query [" + solrQuery + "] failed due to: " + e)
+        logger.error("Query [" + solrQuery + "] failed due to: ", e)
 
         //re-try once in the event of a communications error with the server
         if (SolrSupport.shouldRetry(e)) {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -48,6 +48,46 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       } ))
     })
   }
+
+  test("Zero-result queries should be repeatable") {
+    val properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    val solrInterpreter = new SolrInterpreter(properties)
+    solrInterpreter.open()
+
+    solrInterpreter.interpret(s"use ${collections(0)}", null)
+    val firstNoResultsResponse = solrInterpreter.interpret(s"search q=field1_s:nonexistent_value", null)
+    assert(firstNoResultsResponse.code().eq(InterpreterResult.Code.SUCCESS))
+    assert(firstNoResultsResponse.message().size() == 1)
+    assert(firstNoResultsResponse.message().get(0).getData.equals("<font color=red>Zero results for the query.</font>"))
+
+    val secondNoResultsResponse = solrInterpreter.interpret(s"search q=field1_s:nonexistent_value", null)
+    assert(secondNoResultsResponse.code().eq(InterpreterResult.Code.SUCCESS))
+    assert(secondNoResultsResponse.message().size() == 1)
+    assert(secondNoResultsResponse.message().get(0).getData.equals("<font color=red>Zero results for the query.</font>"))
+
+  }
+
+
+  test("Search commands on empty collections should be repeatable") {
+    val properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    val solrInterpreter = new SolrInterpreter(properties)
+    solrInterpreter.open()
+
+    solrInterpreter.interpret(s"use ${emptyCollection}", null)
+    val firstEmptyCollectionResponse = solrInterpreter.interpret(s"search q=*:*", null)
+    assert(firstEmptyCollectionResponse.code().eq(InterpreterResult.Code.SUCCESS))
+    assert(firstEmptyCollectionResponse.message().size() == 1)
+    assert(firstEmptyCollectionResponse.message().get(0).getData.equals("<font color=red>Zero results for the query.</font>"))
+
+
+    val secondEmptyCollectionResponse = solrInterpreter.interpret(s"search q=*:*", null)
+    assert(secondEmptyCollectionResponse.code().eq(InterpreterResult.Code.SUCCESS))
+    assert(secondEmptyCollectionResponse.message().size() == 1)
+    assert(secondEmptyCollectionResponse.message().get(0).getData.equals("<font color=red>Zero results for the query.</font>"))
+
+  }
   
   // Make sure the collection parameter is passed through to Solr
   test("Test search command specifing non existent collection fails") {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/TestFramework.scala
@@ -69,13 +69,16 @@ trait TestSuiteBuilder extends ZeppelinSolrFunSuite with SolrCloudTestBuilder {}
 
 trait CollectionSuiteBuilder extends TestSuiteBuilder {
   val collections = Array("col1", "col2")
+  val emptyCollection = "emptyCol"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     collections.foreach(f => SolrCloudUtil.buildCollection(zkHost, f, 20, 1, cloudClient))
+    SolrCloudUtil.buildCollection(zkHost, emptyCollection, 0, 1, cloudClient)
   }
 
   override def afterAll(): Unit = {
+    SolrCloudUtil.deleteCollection(emptyCollection, cluster)
     collections.foreach(f => SolrCloudUtil.deleteCollection(f, cluster))
     super.afterAll()
   }


### PR DESCRIPTION
StreamingResultsIterator had code that conditionally closed
HttpSolrClient's in its hasNext() method.  This code originally was
copied from a different project, where this decision made a little more
sense. But in zeppelin-solr, SolrClients are always tied to the
lifecycle of the interpreter and should never be closed prematurely.

This PR removes the errant closure, which was causing any request
after a zero-result query to error out.