### PR TITLE
Add 'help' command to zeppelin-solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Commands:
 #### help
 Display help text in the note window. Command-specific help is provided if a valid command is provided as an argument.
 
-Usage: `help [{specific-command}]`
+Usage: `help {specific-command}`
 
 #### use
 Set a collection to use in the notebook.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ automatically added to out-going jdbc calls if the jdbc Streaming Expression doe
 
 Commands:
 
+#### help
+Display help text in the note window. Command-specific help is provided if a valid command is provided as an argument.
+
+Usage: `help [{specific-command}]`
+
 #### use
 Set a collection to use in the notebook.
 

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,14 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
 
         </plugins>
 

--- a/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
@@ -265,7 +265,7 @@ public class SolrInterpreter extends Interpreter {
     } else if (args.length == 2) {
       switch (args[1]){
         case "use":
-          msg = "Set a default collection for us in other commands.\\nUsage: `use <collection_name>`";
+          msg = "Set a default collection for use in other commands.\\nUsage: `use <collection_name>`";
           break;
         case "search":
           msg = "Issue a search request and display the results.\\nUsage: `search <Solr query params>`";
@@ -277,7 +277,10 @@ public class SolrInterpreter extends Interpreter {
           msg = "Issue a streaming expression request and display the results.\\nUsage: `stream <streaming-expression>`";
           break;
         case "sql":
-          msg = "Issue a SolrSQL query and display the results\\nUsage: `sql <sql-expression>`";
+          msg = "Issue a SQL query and display the results.  NOTE: Solr only supports a subset of traditional SQL " +
+                  "syntax.  See the Solr Reference Guide for details. " +
+                  "https://lucene.apache.org/solr/guide/parallel-sql-interface.html#solr-sql-syntax" +
+                  "\\nUsage: `sql <sql-expression>`";
           break;
         default:
           msg = "Command [" + args[1] + "] not supported.  Supported commands are " + COMMAND_LIST_STRING + ".";

--- a/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
@@ -265,22 +265,22 @@ public class SolrInterpreter extends Interpreter {
     } else if (args.length == 2) {
       switch (args[1]){
         case "use":
-          msg = "Set a default collection for use in other commands.\\nUsage: `use <collection_name>`";
+          msg = "Set a default collection for use in other commands.\nUsage: `use <collection_name>`";
           break;
         case "search":
-          msg = "Issue a search request and display the results.\\nUsage: `search <Solr query params>`";
+          msg = "Issue a search request and display the results.\nUsage: `search <Solr query params>`";
           break;
         case "facet":
-          msg = "Issue a facet request and display the computed counts.\\n Usage: `facet <Solr facet params>`";
+          msg = "Issue a facet request and display the computed counts.\n Usage: `facet <Solr facet params>`";
           break;
         case "stream":
-          msg = "Issue a streaming expression request and display the results.\\nUsage: `stream <streaming-expression>`";
+          msg = "Issue a streaming expression request and display the results.\nUsage: `stream <streaming-expression>`";
           break;
         case "sql":
           msg = "Issue a SQL query and display the results.  NOTE: Solr only supports a subset of traditional SQL " +
                   "syntax.  See the Solr Reference Guide for details. " +
                   "https://lucene.apache.org/solr/guide/parallel-sql-interface.html#solr-sql-syntax" +
-                  "\\nUsage: `sql <sql-expression>`";
+                  "\nUsage: `sql <sql-expression>`";
           break;
         default:
           msg = "Command [" + args[1] + "] not supported.  Supported commands are " + COMMAND_LIST_STRING + ".";

--- a/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
+++ b/src/main/java/com/lucidworks/zeppelin/solr/SolrInterpreter.java
@@ -36,7 +36,8 @@ public class SolrInterpreter extends Interpreter {
   private SolrLukeResponse lukeResponse;
 
   private static final List<String> COMMANDS = Arrays.asList(
-      "use", "search", "facet", "stream", "sql");
+      "help", "use", "search", "facet", "stream", "sql");
+  private static final String COMMAND_LIST_STRING = "[" + String.join(", ", COMMANDS) + "]";
 
   @ZeppelinApi
   public void open() {
@@ -64,8 +65,9 @@ public class SolrInterpreter extends Interpreter {
     }
     String[] args = st.split(" ");
 
-
-    if ("use".equals(args[0])) {
+    if ("help".equals(args[0])) {
+      return determineHelpResponse(args);
+    } else if ("use".equals(args[0])) {
       if (args.length == 2) {
         collection = args[1];
         if(solrClient != null) {
@@ -253,5 +255,35 @@ public class SolrInterpreter extends Interpreter {
 
   public InterpreterResult returnCollectionNull() {
       return new InterpreterResult(InterpreterResult.Code.INCOMPLETE, InterpreterResult.Type.TEXT, "Set collection to use with 'use {collection}' command or set collection in query params for search and facet commands");
+  }
+
+  // Only called when args[0].equals("help")
+  private InterpreterResult determineHelpResponse(String[] args) {
+    String msg = null;
+    if (args.length == 1) {
+      msg = "List of supported commands: " + COMMAND_LIST_STRING + ". Run `help <command>` for information on a specific command";
+    } else if (args.length == 2) {
+      switch (args[1]){
+        case "use":
+          msg = "Set a default collection for us in other commands.\\nUsage: `use <collection_name>`";
+          break;
+        case "search":
+          msg = "Issue a search request and display the results.\\nUsage: `search <Solr query params>`";
+          break;
+        case "facet":
+          msg = "Issue a facet request and display the computed counts.\\n Usage: `facet <Solr facet params>`";
+          break;
+        case "stream":
+          msg = "Issue a streaming expression request and display the results.\\nUsage: `stream <streaming-expression>`";
+          break;
+        case "sql":
+          msg = "Issue a SolrSQL query and display the results\\nUsage: `sql <sql-expression>`";
+          break;
+        default:
+          msg = "Command [" + args[1] + "] not supported.  Supported commands are " + COMMAND_LIST_STRING + ".";
+          return new InterpreterResult(InterpreterResult.Code.ERROR, InterpreterResult.Type.TEXT, msg);
+      }
+    }
+    return new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, msg);
   }
 }

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -24,28 +24,28 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       val result = solrInterpreter.interpret("help use", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Set a default collection for use in other commands.\\nUsage: `use <collection_name>`"))
+      assert(result.message().get(0).getData.equals("Set a default collection for use in other commands.\nUsage: `use <collection_name>`"))
     }
 
     {
       val result = solrInterpreter.interpret("help search", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Issue a search request and display the results.\\nUsage: `search <Solr query params>`"))
+      assert(result.message().get(0).getData.equals("Issue a search request and display the results.\nUsage: `search <Solr query params>`"))
     }
 
     {
       val result = solrInterpreter.interpret("help facet", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Issue a facet request and display the computed counts.\\n Usage: `facet <Solr facet params>`"))
+      assert(result.message().get(0).getData.equals("Issue a facet request and display the computed counts.\n Usage: `facet <Solr facet params>`"))
     }
 
     {
       val result = solrInterpreter.interpret("help stream", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Issue a streaming expression request and display the results.\\nUsage: `stream <streaming-expression>`"))
+      assert(result.message().get(0).getData.equals("Issue a streaming expression request and display the results.\nUsage: `stream <streaming-expression>`"))
     }
 
     {
@@ -55,7 +55,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       assert(result.message().get(0).getData.equals("Issue a SQL query and display the results.  NOTE: Solr only " +
         "supports a subset of traditional SQL syntax.  See the Solr Reference Guide for details. " +
         "https://lucene.apache.org/solr/guide/parallel-sql-interface.html#solr-sql-syntax" +
-        "\\nUsage: `sql <sql-expression>`"))
+        "\nUsage: `sql <sql-expression>`"))
     }
 
     {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -24,7 +24,7 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       val result = solrInterpreter.interpret("help use", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Set a default collection for us in other commands.\\nUsage: `use <collection_name>`"))
+      assert(result.message().get(0).getData.equals("Set a default collection for use in other commands.\\nUsage: `use <collection_name>`"))
     }
 
     {
@@ -52,7 +52,10 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
       val result = solrInterpreter.interpret("help sql", null)
       assert(result.code().eq(InterpreterResult.Code.SUCCESS))
       assert(result.message().size() == 1)
-      assert(result.message().get(0).getData.equals("Issue a SolrSQL query and display the results\\nUsage: `sql <sql-expression>`"))
+      assert(result.message().get(0).getData.equals("Issue a SQL query and display the results.  NOTE: Solr only " +
+        "supports a subset of traditional SQL syntax.  See the Solr Reference Guide for details. " +
+        "https://lucene.apache.org/solr/guide/parallel-sql-interface.html#solr-sql-syntax" +
+        "\\nUsage: `sql <sql-expression>`"))
     }
 
     {

--- a/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
+++ b/src/test/scala/com/lucidworks/zeppelin/solr/SolrInterpreterCommandsTest.scala
@@ -6,7 +6,62 @@ import org.apache.zeppelin.interpreter.InterpreterResult
 
 class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
 
+  test("Test 'help' command") {
+    val properties = new Properties()
+    properties.put(SolrInterpreter.BASE_URL, baseUrl)
+    val solrInterpreter = new SolrInterpreter(properties)
+    solrInterpreter.open()
 
+    {
+      val result = solrInterpreter.interpret("help", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("List of supported commands: [help, use, search, facet, stream, sql]. " +
+        "Run `help <command>` for information on a specific command"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help use", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Set a default collection for us in other commands.\\nUsage: `use <collection_name>`"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help search", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Issue a search request and display the results.\\nUsage: `search <Solr query params>`"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help facet", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Issue a facet request and display the computed counts.\\n Usage: `facet <Solr facet params>`"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help stream", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Issue a streaming expression request and display the results.\\nUsage: `stream <streaming-expression>`"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help sql", null)
+      assert(result.code().eq(InterpreterResult.Code.SUCCESS))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Issue a SolrSQL query and display the results\\nUsage: `sql <sql-expression>`"))
+    }
+
+    {
+      val result = solrInterpreter.interpret("help nonexistentCommand", null)
+      assert(result.code().eq(InterpreterResult.Code.ERROR))
+      assert(result.message().size() == 1)
+      assert(result.message().get(0).getData.equals("Command [nonexistentCommand] not supported.  Supported commands are [help, use, search, facet, stream, sql]."))
+    }
+  }
 
   test("Test use command") {
     val properties = new Properties()
@@ -17,7 +72,6 @@ class SolrInterpreterCommandsTest extends CollectionSuiteBuilder {
     val result = solrInterpreter.interpret(s"use ${collections(0)}", null)
     assert(result.code().eq(InterpreterResult.Code.SUCCESS))
   }
-
 
 
   test("Test search command") {


### PR DESCRIPTION
Adds a simple 'help' command.  There's not extensive docs on each
command, since the syntax is essentially Solr's query-param syntax. But
it's useful for users just getting started with zeppelin-solr or who
have forgotten a particular keyword.