### PR TITLE
LUCENESOLR-1811: Remove jdbc.url, .driver defaults

### DIFF
--- a/src/main/resources/interpreter-setting.json
+++ b/src/main/resources/interpreter-setting.json
@@ -19,14 +19,14 @@
       "jdbc.url": {
         "envName": null,
         "propertyName": "jdbc.url",
-        "defaultValue": "jdbc:hive2://localhost:8768/default;transportMode=http;httpPath=fusion;user=admin;password=password123",
+        "defaultValue": "",
         "description": "The jdbc connection url (Only used with the jdbc Streaming Expression if the connection is not specified.))"
       },
       "jdbc.driver": {
         "envName": null,
         "propertyName": "jdbc.driver",
-        "defaultValue": "org.apache.hive.jdbc.HiveDriver",
-        "description": "The jdbc driver (Only used with the jdbc Streaming Expression if the connection is not specified.)"
+        "defaultValue": "",
+        "description": "The classname of a valid, accessible jdbc driver (Only used with the jdbc Streaming Expression if the connection is not specified.)"
       }
     },
     "editor": {


### PR DESCRIPTION
The interpreter settings included a JDBC url which assumed a local
Fusion4 install.  This was convenient for developers at the time, but
  1. Fusion 5 has made this value incorrect now anyways, and
  2. It makes little sense in an open source interpreter not aimed
     specifically at Fusion.

This commit replaces the default values for these properties with
empty-string, forcing users to provide a value themselves.